### PR TITLE
chore: add missing parameter indexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 19.0.6 [#100](https://github.com/openfisca/openfisca-nouvelle-caledonie/pull/100)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : toutes.
+* Zones impactées : `parameters/prelevements_obligatoires/impot_revenu`.
+* Détails :
+  - Ajout des index de paramètres manquants pour assurer la cohérence de l'arborescence des paramètres.
+
+
 ## 19.0.4 [#97](https://github.com/openfisca/openfisca-nouvelle-caledonie/pull/97)
 
 * Évolution du système socio-fiscal et améliorations techniques.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = ["setuptools>=61"]
 [project]
 name = "openfisca-nouvelle-caledonie"
 
-version = "19.0.4"
+version = "19.0.6"
 description = "OpenFisca Rules as Code model for Nouvelle Calédonie."
 readme = "README.md"
 keywords = [ "benefit", "microsimulation", "rac", "rules-as-code", "tax" ]


### PR DESCRIPTION
Amélioration technique.
Détails :
Ajout des fichiers index.yaml manquants dans l'arborescence des paramètres.
Correction d'une faute dans la description du taux normal des plus-values professionnelles.